### PR TITLE
Build powershell v7.0.0, v7.0.1, v7.0.2, and v7.0.3 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        PS_VERSION: [7.0.1, 7.0.2, 7.0.3]
+        PS_VERSION: [7.0.3, 7.0.2, 7.0.1, 7.0.0]
         OS: [alpine]
         OS_VARIANT: ['3.10', 3.9, 3.8]
         TOOL_VARIANT: [git, git-ssh, git-sudo]
@@ -117,9 +117,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        PS_VERSION: [7.0.1, 7.0.2, 7.0.3]
+        PS_VERSION: [7.0.3, 7.0.2, 7.0.1, 7.0.0]
         OS: [ubuntu]
-        OS_VARIANT: [18.04]
+        OS_VARIANT: [18.04, 16.04]
         TOOL_VARIANT: [git, git-ssh, git-sudo]
         include:
         - OS: ubuntu


### PR DESCRIPTION
Adds additional `alpine` and `ubuntu` based powershell images not included in #3.