### PR TITLE
Refactor: Remove setting of CMD value in Dockerfiles

### DIFF
--- a/variants/alpine/git-sudo/Dockerfile
+++ b/variants/alpine/git-sudo/Dockerfile
@@ -14,4 +14,3 @@ RUN apk add --no-cache \
         git \
         sudo
 
-CMD ["pwsh"]

--- a/variants/alpine/git/Dockerfile
+++ b/variants/alpine/git/Dockerfile
@@ -13,4 +13,3 @@ ENV COMPlus_EnableDiagnostics=0
 RUN apk add --no-cache \
         git
 
-CMD ["pwsh"]

--- a/variants/ubuntu/git-sudo/Dockerfile
+++ b/variants/ubuntu/git-sudo/Dockerfile
@@ -16,4 +16,3 @@ RUN apt-get update \
         sudo \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["pwsh"]

--- a/variants/ubuntu/git/Dockerfile
+++ b/variants/ubuntu/git/Dockerfile
@@ -15,4 +15,3 @@ RUN apt-get update \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["pwsh"]


### PR DESCRIPTION
The default CMD within official PowerShell images will be used instead.